### PR TITLE
fix: remove refocus code because it breaks ie11

### DIFF
--- a/lib/core/src/datetimepicker/datetimepicker.ts
+++ b/lib/core/src/datetimepicker/datetimepicker.ts
@@ -313,8 +313,8 @@ export class MatDatetimepicker<D> implements OnDestroy {
     if (this._focusedElementBeforeOpen &&
       typeof this._focusedElementBeforeOpen.focus === "function") {
 
-      this._focusedElementBeforeOpen.focus();
-      this._focusedElementBeforeOpen = null;
+      // this._focusedElementBeforeOpen.focus();
+      // this._focusedElementBeforeOpen = null;
     }
 
     this.opened = false;


### PR DESCRIPTION
ie11 does not handle the last focused element correctly and directly refocuses the datepicker, which makes it impossible to close the datepicker