### PR TITLE
feat(#15): add override of the popup date label

### DIFF
--- a/projects/core/src/adapter/datetime-formats.ts
+++ b/projects/core/src/adapter/datetime-formats.ts
@@ -15,6 +15,7 @@ export interface MatDatetimeFormats {
     monthYearLabel: any;
     dateA11yLabel: any;
     monthYearA11yLabel: any;
+    popupHeaderDateLabel: any;
   };
 }
 

--- a/projects/core/src/adapter/native-datetime-formats.ts
+++ b/projects/core/src/adapter/native-datetime-formats.ts
@@ -9,6 +9,7 @@ export const MAT_NATIVE_DATETIME_FORMATS: MatDatetimeFormats = {
     timeInput: {hour: "2-digit", minute: "2-digit"},
     monthYearLabel: {year: "numeric", month: "short"},
     dateA11yLabel: {year: "numeric", month: "long", day: "numeric"},
-    monthYearA11yLabel: {year: "numeric", month: "long"}
+    monthYearA11yLabel: {year: "numeric", month: "long"},
+    popupHeaderDateLabel: {weekday: "short", month: "short", day: "2-digit"}
   }
 };

--- a/projects/core/src/datetimepicker/calendar.ts
+++ b/projects/core/src/datetimepicker/calendar.ts
@@ -170,13 +170,12 @@ export class MatDatetimepickerCalendar<D> implements AfterContentInit, OnDestroy
   }
 
   get _dateLabel(): string {
-    if (this.type === "month") {
-      return this._adapter.getMonthNames("long")[this._adapter.getMonth(this._activeDate)];
+    switch (this.type) {
+      case "month":
+        return this._adapter.getMonthNames("long")[this._adapter.getMonth(this._activeDate)];
+      default:
+        return this._adapter.format(this._activeDate, this._dateFormats.display.popupHeaderDateLabel);
     }
-    const day = this._adapter.getDayOfWeekNames("short")[this._adapter.getDayOfWeek(this._activeDate)];
-    const month = this._adapter.getMonthNames("short")[this._adapter.getMonth(this._activeDate)];
-    const date = this._adapter.getDateNames()[this._adapter.getDate(this._activeDate) - 1];
-    return `${day}, ${month} ${date}`;
   }
 
   get _hoursLabel(): string {

--- a/projects/moment/src/adapter/moment-datetime-formats.ts
+++ b/projects/moment/src/adapter/moment-datetime-formats.ts
@@ -14,6 +14,7 @@ export const MAT_MOMENT_DATETIME_FORMATS: MatDatetimeFormats = {
     timeInput: "LT",
     monthYearLabel: "MMM YYYY",
     dateA11yLabel: "LL",
-    monthYearA11yLabel: "MMMM YYYY"
+    monthYearA11yLabel: "MMMM YYYY",
+    popupHeaderDateLabel: "ddd, DD MMM"
   }
 };


### PR DESCRIPTION
This adds a new `popupHeaderDateLabel` field that defaults to the current format but can be overridden by providing a custom `MAT_DATETIME_FORMATS` instance.

Signed-off-by: Peter Leibiger <kuhnroyal@gmail.com>
