### PR TITLE
fix(#40): Normalize date on month selection

### DIFF
--- a/projects/core/src/datetimepicker/year-view.ts
+++ b/projects/core/src/datetimepicker/year-view.ts
@@ -115,9 +115,11 @@ export class MatDatetimepickerYearView<D> implements AfterContentInit {
 
   /** Handles when a new month is selected. */
   _monthSelected(month: number) {
+    const normalizedDate = this._adapter.createDatetime(this._adapter.getYear(this.activeDate), month, 1, 0, 0);
+
     this.selectedChange.emit(this._adapter.createDatetime(
       this._adapter.getYear(this.activeDate), month,
-      this._adapter.getDate(this.activeDate),
+      Math.min(this._adapter.getDate(this.activeDate), this._adapter.getNumDaysInMonth(normalizedDate)),
       this._adapter.getHour(this.activeDate),
       this._adapter.getMinute(this.activeDate)));
     if (this.type === "month") {


### PR DESCRIPTION
Use days in newly selected month if day in currently selected  month is too high.

Signed-off-by: Peter Leibiger <kuhnroyal@gmail.com>