### PR TITLE
Fix moment import

### DIFF
--- a/projects/moment/src/adapter/moment-datetime-adapter.ts
+++ b/projects/moment/src/adapter/moment-datetime-adapter.ts
@@ -6,7 +6,7 @@ import {DatetimeAdapter} from "@mat-datetimepicker/core";
 import * as moment_ from "moment";
 import {Moment} from "moment";
 
-const moment = moment_;
+const moment = 'default' in moment_ ? moment_['default'] : moment_;
 
 function range<T>(length: number, valueFunction: (index: number) => T): T[] {
   const valuesArray = Array(length);


### PR DESCRIPTION
I got a "moment is not a function" error when using this package while running jest tests.
This small change in the import logic for the moment package fixed that.