### PR TITLE
Fixing Bug #133 (Min / Max too close seems not working)

### DIFF
--- a/projects/core/src/adapter/datetime-adapter.ts
+++ b/projects/core/src/adapter/datetime-adapter.ts
@@ -28,10 +28,10 @@ export abstract class DatetimeAdapter<D> extends DateAdapter<D> {
     return (this.isDateInstance(obj) && this.isValid(obj)) ? obj : null;
   }
 
-  compareDatetime(first: D, second: D): number {
+  compareDatetime(first: D, second: D, respectMinutePart: boolean = true): number {
     return this.compareDate(first, second) ||
       this.getHour(first) - this.getHour(second) ||
-      this.getMinute(first) - this.getMinute(second);
+      (respectMinutePart && this.getMinute(first) - this.getMinute(second));
   }
 
   sameDatetime(first: D | null, second: D | null): boolean {

--- a/projects/core/src/datetimepicker/clock.ts
+++ b/projects/core/src/datetimepicker/clock.ts
@@ -217,8 +217,8 @@ export class MatDatetimepickerClock<D> implements AfterContentInit {
           this._adapter.getMonth(this.activeDate),
           this._adapter.getDate(this.activeDate), i, 0);
         let enabled =
-          (!this.minDate || this._adapter.compareDatetime(date, this.minDate) >= 0) &&
-          (!this.maxDate || this._adapter.compareDatetime(date, this.maxDate) <= 0) &&
+          (!this.minDate || this._adapter.compareDatetime(date, this.minDate, false) >= 0) &&
+          (!this.maxDate || this._adapter.compareDatetime(date, this.maxDate, false) <= 0) &&
           (!this.dateFilter || this.dateFilter(date, MatDatetimepickerFilterType.HOUR));
         this._hours.push({
           value: i,
@@ -302,11 +302,9 @@ export class MatDatetimepickerClock<D> implements AfterContentInit {
         this._adapter.getDate(this.activeDate), this._adapter.getHour(this.activeDate), value);
     }
 
-    const clamped = this._adapter.clampDate(date, this.minDate, this.maxDate);
-    if (date === clamped) {
-      this._timeChanged = true;
-      this.activeDate = clamped;
-      this.activeDateChange.emit(this.activeDate);
-    }
+    this._timeChanged = true;
+    this.activeDate = date;
+    this.activeDateChange.emit(this.activeDate);
   }
 }
+


### PR DESCRIPTION
Example setting Min/Max to
  min = new Date("2018-11-09T08:20:00.000Z");
  max = new Date("2018-11-09T09:10:00.000Z");

first point: currently it's not possible to select the hour part because compareDatetime() returns false in that case.

second point: set time doesn't emit a date change event cause the date is clamped to the min/max value. it should however emit the clamped value (from the activeDate setter)