### PR TITLE
ci(versioning): requires a full depth checkout

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,22 +8,6 @@ on:
     paths:
       - .github/version.json
 jobs:
-  publish:
-    name: Publish to GitHub Pages
-    runs-on: ubuntu-20.04
-    environment: NPM
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
-          node-version: '16'
-      - run: npm ci
-      - run: npm run build:lib
-      - run: npm run build:pages
-      - run: npm run publish:pages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   deploy:
     name: Deploy to npmjs.org
     runs-on: ubuntu-20.04
@@ -40,5 +24,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm publish dist/moment
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish:
+    name: Publish to GitHub Pages
+    runs-on: ubuntu-20.04
+    environment: NPM
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+          node-version: '16'
+      - run: npm ci
+      - run: npm run build:lib
+      - run: npm run build:pages
+      - run: npm run publish:pages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: '0'
           token: ${{ secrets.ACTION_TOKEN }}
       - run: |
           git config user.name "GitHub Actions Bot"


### PR DESCRIPTION
the action will have an invalid version bump otherwise.
see also: https://github.com/kuhnroyal/mat-datetimepicker/runs/4641341226?check_suite_focus=true.