### PR TITLE
ci: add registry URL to setup-node action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           cache: 'npm'
           node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build:lib
       - run: npm publish ./dist/core
@@ -38,6 +39,7 @@ jobs:
         with:
           cache: 'npm'
           node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build:lib
       - run: npm run build:pages


### PR DESCRIPTION
According to https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages the registry URL has to be added to the setup-node action