### PR TITLE
ci: create github releases as well

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  deploy:
+    name: Create GitHub Release
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            CHANGELOG.md
+            LICENSE
+            README.md
+          name: Release ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this will (hopefully 😉) create a GitHub release as well from the pushed `chore(release)` tag. I've never used this action before.