### PR TITLE
fix: use ref name for github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,5 @@ jobs:
             CHANGELOG.md
             LICENSE
             README.md
-          name: Release ${{ github.ref }}
+          name: Release $GITHUB_REF_NAME
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -29,4 +29,4 @@ jobs:
           node-version: '16'
       - run: npm ci
       - run: npx --no-install standard-version
-      - run: git push --follow-tags origin ${{ github.ref }}
+      - run: git push --follow-tags origin $GITHUB_REF


### PR DESCRIPTION
release currently contain the `refs/tag`-prefix which does not look nice.