### PR TITLE
fix(toggle): avoid interfering with external click listener

### DIFF
--- a/projects/core/src/datetimepicker/datetimepicker-toggle.html
+++ b/projects/core/src/datetimepicker/datetimepicker-toggle.html
@@ -1,5 +1,4 @@
 <button
-  (click)="_open($event)"
   [attr.aria-label]="_intl.openCalendarLabel"
   [disabled]="disabled"
   mat-icon-button

--- a/projects/core/src/datetimepicker/datetimepicker-toggle.ts
+++ b/projects/core/src/datetimepicker/datetimepicker-toggle.ts
@@ -19,6 +19,10 @@ import { MatDatetimepickerComponent } from './datetimepicker';
   templateUrl: 'datetimepicker-toggle.html',
   host: {
     class: 'mat-datetimepicker-toggle',
+    // Bind the `click` on the host, rather than the inner `button`, so that we can call `stopPropagation`
+    // on it without affecting the user's `click` handlers. We need to stop it so that the input doesn't
+    // get focused automatically by the form field (See https://github.com/angular/components/pull/21856).
+    '(click)': '_open($event)',
   },
   exportAs: 'matDatetimepickerToggle',
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Currently the picker toggle's `click` listener is on the inner `button` element and we
call `stopPropagation` on it in order to prevent the form field from focusing the input.
The problem is that doing so will also prevent any custom `click` handler that the user
might have added to the `mat-datetimepicker-toggle`.

These changes resolve the issue by moving the listener directly onto the toggle host
which will invoke any external listeners while still allowing us to stop its propagation.