### PR TITLE
fix: prevent closing the active view when clicking on a disabled hour/minute

### DIFF
--- a/projects/core/src/datetimepicker/clock.ts
+++ b/projects/core/src/datetimepicker/clock.ts
@@ -338,6 +338,12 @@ export class MatDatetimepickerClockComponent<D> implements AfterContentInit {
           ? 0
           : value + 12;
       }
+
+      // Don't close the hours view if an invalid hour is clicked.
+      if (!this._hours.find((h) => h?.['value'] === value)?.['enabled']) {
+        return;
+      }
+
       date = this._adapter.createDatetime(
         this._adapter.getYear(this.activeDate),
         this._adapter.getMonth(this.activeDate),
@@ -352,6 +358,12 @@ export class MatDatetimepickerClockComponent<D> implements AfterContentInit {
       if (value === 60) {
         value = 0;
       }
+
+      // Don't close the minutes view if an invalid minute is clicked.
+      if (!this._minutes.find((m) => m?.['value'] === value)?.['enabled']) {
+        return;
+      }
+
       date = this._adapter.createDatetime(
         this._adapter.getYear(this.activeDate),
         this._adapter.getMonth(this.activeDate),


### PR DESCRIPTION
A click on a disabled item should do nothing.
these changes fixes an issue with me, And I think it will fix https://github.com/kuhnroyal/mat-datetimepicker/issues/158 as well.