### PR TITLE
fix: peer dependencies in packages

### DIFF
--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -11,8 +11,8 @@
   },
   "peerDependencies": {
     "@angular/cdk": "^15.0.0",
-    "@angular/common": "^15.0.1",
-    "@angular/core": "^15.0.1",
+    "@angular/common": "^15.0.0",
+    "@angular/core": "^15.0.0",
     "@angular/material": "^15.0.0"
   },
   "dependencies": {

--- a/projects/moment/package.json
+++ b/projects/moment/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/cdk": "^15.0.0",
-    "@angular/common": "^15.0.1",
-    "@angular/core": "^15.0.1",
+    "@angular/common": "^15.0.0",
+    "@angular/core": "^15.0.0",
     "@angular/material": "^15.0.0",
     "@angular/material-moment-adapter": "^15.0.0",
     "@mat-datetimepicker/core": "^11.0.0"


### PR DESCRIPTION
> BREAKING CHANGE: this will require `@angular/core@^15.0.0`!

@gsontag I was too lazy while reviewing, the footer must be `BREAKING CHANGE` not `BREAKING CHANGE_S_`.. I've added this.

@kuhnroyal I will not merge this unless we have a solution for [this](https://github.com/kuhnroyal/mat-datetimepicker/actions/runs/3576245595/jobs/6013817156#step:6:314). any chance to exclude the `GITHUB_TOKEN` from this rule?

- [x] made sure `GITHUB_TOKEN` can push to `release`