### PR TITLE
ci: split lts and support builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,24 @@ jobs:
     name: Node.js CI
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build:lib
+      - run: npm test
+  support:
+    name: Node.js unstable
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [19.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "webpack-bundle-analyzer": "4.8.0"
       },
       "engines": {
-        "node": ">=18.14.0 "
+        "node": ">=18.15.0 "
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -119,15 +119,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.2.tgz",
-      "integrity": "sha512-iSav72D66ZguuIg7yZz/VcbrITidRmjBUApu1GAVfXd4rYZhdWygR072LAsAUNnSDAGwmIICFzj86c8LxYOtzA==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.3.tgz",
+      "integrity": "sha512-GMGvCn0BOgDrNIbx2BP1kKWzCZY1SbKZmT6HdQE0tHfKNKfGocZMKnXlUWXbbTIGGmHyipu+edgIKbGKhYs66w==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1502.2",
-        "@angular-devkit/build-webpack": "0.1502.2",
-        "@angular-devkit/core": "15.2.2",
+        "@angular-devkit/architect": "0.1502.3",
+        "@angular-devkit/build-webpack": "0.1502.3",
+        "@angular-devkit/core": "15.2.3",
         "@babel/core": "7.20.12",
         "@babel/generator": "7.20.14",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -139,7 +139,7 @@
         "@babel/runtime": "7.20.13",
         "@babel/template": "7.20.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "15.2.2",
+        "@ngtools/webpack": "15.2.3",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.13",
         "babel-loader": "9.1.2",
@@ -228,6 +228,47 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
+      "version": "0.1502.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.3.tgz",
+      "integrity": "sha512-vWwkMmXHT3D3ZDz2HRS/LYBSO8i/XqkC1hG5TWWgsDZvwSLfDJSX0mvsYglpdF81Ene/mnjau+Waj0HJMuQVHQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "15.2.3",
+        "rxjs": "6.6.7"
+      },
+      "engines": {
+        "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.3.tgz",
+      "integrity": "sha512-/x6rnIc2nbosg9zsneBCdlW+qPJCnbItrzok6Pf5n+3YEY3DFNt8cEgvNymW/u8uiehLYFoAoCq4HIwEXhzoYQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.0",
+        "rxjs": "6.6.7",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -247,12 +288,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1502.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.2.tgz",
-      "integrity": "sha512-y/K6mi4oYjxdSuktdI/HznfxwWc2U8d6SJHdQeoPA6TRsBbWjEk1gcOt3f54PIsExLiDe6Oq1KjbfLTpNSu0kA==",
+      "version": "0.1502.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.3.tgz",
+      "integrity": "sha512-VNgsLkJx1+TBg9YcHUYJWNXIeFQS2/CKJdZjJ73PTa5GVkxnIYRwCs3StmbaVT8n7Sx70fgp59COppk4S6SoFQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1502.2",
+        "@angular-devkit/architect": "0.1502.3",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -263,6 +304,47 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^4.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
+      "version": "0.1502.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.3.tgz",
+      "integrity": "sha512-vWwkMmXHT3D3ZDz2HRS/LYBSO8i/XqkC1hG5TWWgsDZvwSLfDJSX0mvsYglpdF81Ene/mnjau+Waj0HJMuQVHQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "15.2.3",
+        "rxjs": "6.6.7"
+      },
+      "engines": {
+        "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.3.tgz",
+      "integrity": "sha512-/x6rnIc2nbosg9zsneBCdlW+qPJCnbItrzok6Pf5n+3YEY3DFNt8cEgvNymW/u8uiehLYFoAoCq4HIwEXhzoYQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.0",
+        "rxjs": "6.6.7",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
@@ -4410,9 +4492,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.2.tgz",
-      "integrity": "sha512-xHd5CC0Wi0a/CKfKoOC4Bwb1FVjy0esj22eQAkVh0iDKeiAQH4UG/VRmsdSHvto1z0IzGbMSt4hRbv4h2aYIdw==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.3.tgz",
+      "integrity": "sha512-mds3EXzEA6nn6X7gBYv0W6yCTw53EmYGFdyK1ZFl/TPboKrkhn9J5SjSDPEc7UQC3tjVwWnOxgNxkPOBpbQzIw==",
       "dev": true,
       "engines": {
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "webpack-bundle-analyzer": "4.8.0"
   },
   "engines": {
-    "node": ">=18.14.0 "
+    "node": ">=18.15.0 "
   }
 }


### PR DESCRIPTION
Odd numbered Node.js versions will not enter LTS status and should not be used for production. For more information, please see https://nodejs.org/en/about/releases/.