### PR TITLE
fix(#682): remove ngSwitchDefault

### DIFF
--- a/projects/core/src/datetimepicker/calendar.html
+++ b/projects/core/src/datetimepicker/calendar.html
@@ -150,7 +150,6 @@
     (_userSelection)="_userSelected()"
     (activeDateChange)="_onActiveDateChange($event)"
     (selectedChange)="_timeSelected($event)"
-    *ngSwitchDefault
     [dateFilter]="dateFilter"
     [interval]="timeInterval"
     [maxDate]="maxDate"


### PR DESCRIPTION
the `@default` block is already contained in `calendar.html#148`.

closes #682.