### PR TITLE
Update release workflow with OIDC permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: Release
+
 on:
   push:
     branches:
       - release
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   release:
     name: Release NPM Packages
@@ -20,6 +26,5 @@ jobs:
       - run: npm run build:lib
       - env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx --no-install semantic-release


### PR DESCRIPTION
The legacy tokens no longer work. I followed https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/ & https://docs.npmjs.com/trusted-publishers and added the trusted publisher settings.