### PR TITLE
fix: missing character in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install --save @mat-datetimepicker/core
 And for the moment adapter:
 
 ```sh
-npm install --save @angular/material-moment-adapter mat-datetimepicker/moment
+npm install --save @angular/material-moment-adapter @mat-datetimepicker/moment
 ```
 
 ## Setup


### PR DESCRIPTION
There is a typo in the instructions, without the "@" it will try to install it from github.  
I think it is pretty important because if someone tries to to create that repo it will be able to install anything in the project

```
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/mat-datetimepicker/moment.git
npm error git@github.com: Permission denied (publickey).
npm error fatal: Could not read from remote repository.
```